### PR TITLE
Add serverless-ruby Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ Dockerfiles for images we are releasing publicly to dockerhub
   secrets decryption, and others
 * [nodejs-aws-builder](nodejs-aws-builder/): image providing a nodejs runtime
   on top of all the goodness of the `aws-cli-builder`
+* [serverless-ruby](serverless-ruby/): image providing a ruby environment to
+  deploy serverless ruby projects

--- a/serverless-ruby/Dockerfile
+++ b/serverless-ruby/Dockerfile
@@ -1,0 +1,47 @@
+################################################################
+# Dockerfile to create the serverless-ruby image which
+# is to be used to deploy serverless ruby projects generated
+# with pardner.
+#
+# Provides:
+#
+#    ruby          2.7.3
+#    bundler      1.17.2
+#    node           14.x
+#    npm             6.x
+#    yarn         1.19.1
+#    aws-cli    1.16.261
+#    jq            1.5-1
+#    nc             7.50
+#
+# Current Image Version w/above deps
+#
+#   1.4.0
+#
+# To build image, from the serverless-ruby directory run:
+#
+#    docker build -t shippingeasy/serverless-ruby:<version> .
+#
+# To launch container:
+#
+#    docker run -ti --rm shippingeasy/serverless-ruby:<version>
+#
+# To push image to dockerhub:
+#
+#    docker push shippingeasy/serverless-ruby:<version>
+#
+################################################################################
+FROM lambci/lambda:build-ruby2.7
+
+RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -                                         \
+ && curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo                  \
+ && yum install -y nodejs yarn                                                                      \
+ && curl -sL https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 > /usr/local/bin/jq \
+ && chmod +x /usr/local/bin/jq                                                                      \
+ && npm install -g serverless                                                                       \
+ && yum install -y nc                                                                               \
+ && yum clean all
+
+ENV PATH /root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin:$PATH
+
+CMD '/bin/bash'

--- a/serverless-ruby/README.md
+++ b/serverless-ruby/README.md
@@ -1,0 +1,43 @@
+# serverless-ruby
+Docker image for the serverless-ruby image which is used to deploy serverless
+ruby projects that may have been generated with Pardner
+
+## Versions
+
+### 1.4.0
+
+| library | version |
+|---------|---------|
+|ruby     |2.7.3    |
+|bundler  |1.17.2   |
+|node     |14.x     |
+|npm      |6.x      |
+|yarn     |1.19.1   |
+|aws-cli  |1.16.261 |
+|jq       |1.5-1    |
+|nc       |7.50     |
+
+### 1.3.0
+
+| library | version |
+|---------|---------|
+|ruby     |2.7.3    |
+|bundler  |1.17.2   |
+|node     |12.x     |
+|npm      |6.x      |
+|yarn     |1.19.1   |
+|aws-cli  |1.16.261 |
+|jq       |1.5-1    |
+|nc       |7.50     |
+
+## Releasing
+1. Build the image locally with `docker build -t shippingeasy/serverless-ruby:<version> .`
+  1. If you'd like to verify versions in a bash shell, run `docker run -ti --rm shippingeasy/serverless-ruby:<version>`
+2. Make sure you are logged in to dockerhub with `docker login`
+4. Push the image to dockerhub with `docker push shippingeasy/serverless-ruby:<version>`
+
+## Dependencies
+
+- [Branded Tracking](https://github.com/shipstation/branded-tracking) relies on this image for [Backend CI](https://github.com/shipstation/branded-tracking/blob/shipengine-intg/.build/backend-ci-docker-compose.yaml#L39) and deploys ([frontend](https://github.com/shipstation/branded-tracking/blob/shipengine-intg/.build/frontend_deploy.yaml#L34), [backend](https://github.com/shipstation/branded-tracking/blob/shipengine-intg/.build/backend_deploy.yaml#L38)).
+- [Pardner](https://github.com/ShippingEasy/pardner) relies on this image for [CI](https://github.com/ShippingEasy/pardner/blob/master/localstack-ruby/.buildkite/ci-docker-environment.yaml#L13) and [Deploys](https://github.com/ShippingEasy/pardner/blob/master/localstack-ruby/.buildkite/deploy.yaml#L26)
+- [PostShip Webhooks](https://github.com/ShippingEasy/postship_webhooks) relies on this image for [CI](https://github.com/ShippingEasy/postship_webhooks/blob/staging/.buildkite/ci-docker-environment.yaml#L13) and [Deploys](https://github.com/shipstation/branded-tracking/blob/shipengine-intg/.build/frontend_deploy.yaml#L34)


### PR DESCRIPTION
 ### Why?
This docker image was being hosted in the [Pardner](https://github.com/ShippingEasy/pardner)
repository, which made it difficult to find if you needed to make a
change to the image but didn't know the historical context of where it
was used.

Logically, since it is a [public image](https://hub.docker.com/r/shippingeasy/serverless-ruby/tags), it should be in this repository

 ### What?
- Add a `serverless-ruby` directory with a dockerfile for v1.4.0 of the
`serverless-ruby` build image
- Add a README for the serverless-ruby image and version tables for  `1.4.0`
and `1.3.0`.
- Add references to dependencies that rely on this image
- Add `serverless-ruby` to the top level README